### PR TITLE
fix test-adapter

### DIFF
--- a/pkg/cmd/server/start.go
+++ b/pkg/cmd/server/start.go
@@ -60,7 +60,7 @@ func (o CustomMetricsAdapterServerOptions) Config() (*apiserver.Config, error) {
 
 	serverConfig := genericapiserver.NewConfig(apiserver.Codecs)
 
-	if err := o.SecureServing.ApplyTo(&serverConfig.SecureServing, &serverConfig.LoopbackClientConfig); err != nil {
+	if err := o.SecureServing.ApplyTo(serverConfig); err != nil {
 		return nil, err
 	}
 

--- a/test-adapter/provider/provider.go
+++ b/test-adapter/provider/provider.go
@@ -210,12 +210,10 @@ func (p *testingProvider) metricFor(value resource.Quantity, name types.Namespac
 	if err != nil {
 		return nil, err
 	}
-	metricId := custom_metrics.MetricIdentifier{
-		Name: info.Metric,
-	}
+
 	return &custom_metrics.MetricValue{
 		DescribedObject: objRef,
-		Metric:     	 metricId,
+		MetricName:      info.Metric,
 		Timestamp:       metav1.Time{time.Now()},
 		Value:           value,
 	}, nil


### PR DESCRIPTION
Update provider for build to work.
Kept the previous version of the secureserver, this will be bumped in the next version.